### PR TITLE
Update to hyper 1.x and other dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# 2.0.0
+
+- Option `websocket_config.max_send_queue` was replaced by
+  `websocket_config.write_buffer_size` and
+  `websocket_config.max_write_buffer_size`
+- Target kube API version 1.31
+- Upgrade to hyper 1.0
+- Upgrade all dependencies, base image and to Rust 1.81

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,6 @@ dependencies = [
  "kube",
  "kube-runtime",
  "log",
- "once_cell",
  "prometheus",
  "regex",
  "schemars",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,18 +40,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
+name = "allocator-api2"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
+name = "anstream"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
- "libc",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -59,6 +99,40 @@ name = "anyhow"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
 
 [[package]]
 name = "async-trait"
@@ -111,21 +185,21 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -181,11 +255,33 @@ version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
- "android-tzdata",
- "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -204,6 +300,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -225,27 +327,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.4"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.4"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -285,27 +387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,16 +399,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
-name = "env_logger"
-version = "0.10.2"
+name = "env_filter"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
- "humantime",
- "is-terminal",
  "log",
  "regex",
- "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -337,25 +428,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -463,10 +569,10 @@ dependencies = [
  "bytes",
  "env_logger",
  "futures",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "http-serde",
- "hyper 1.4.1",
+ "hyper",
  "hyper-tungstenite",
  "hyper-util",
  "jsonwebtoken",
@@ -504,8 +610,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -525,7 +633,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -538,6 +646,34 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -546,20 +682,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
-name = "hermit-abi"
-version = "0.4.0"
+name = "home"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "bytes",
- "fnv",
- "itoa",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -575,23 +703,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http",
 ]
 
 [[package]]
@@ -602,16 +719,10 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "http-serde"
@@ -619,7 +730,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
 dependencies = [
- "http 1.1.0",
+ "http",
  "serde",
 ]
 
@@ -643,29 +754,6 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
@@ -674,8 +762,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http 1.1.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -686,33 +774,55 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-openssl"
-version = "0.9.2"
+name = "hyper-http-proxy"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ee5d7a8f718585d1c3c61dfde28ef5b0bb14734b4db13f5ada856cdc6c612b"
+checksum = "5d06dbdfbacf34d996c6fb540a71a684a7aae9056c71951163af8a8a4c07b9a4"
 dependencies = [
- "http 0.2.12",
- "hyper 0.14.30",
- "linked_hash_set",
- "once_cell",
- "openssl",
- "openssl-sys",
- "parking_lot",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls-native-certs 0.7.3",
  "tokio",
- "tokio-openssl",
- "tower-layer",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rustls",
+ "rustls-native-certs 0.8.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
 dependencies = [
- "hyper 0.14.30",
+ "hyper",
+ "hyper-util",
  "pin-project-lite",
  "tokio",
- "tokio-io-timeout",
+ "tower-service",
 ]
 
 [[package]]
@@ -722,7 +832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "426356dc8c52c5a18c5a6c12226c03362f98e4723716074f8010051934cb451c"
 dependencies = [
  "http-body-util",
- "hyper 1.4.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -739,37 +849,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
- "hyper 1.4.1",
+ "http",
+ "http-body",
+ "hyper",
  "pin-project-lite",
  "socket2",
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -808,15 +895,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.13"
+name = "is_terminal_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
-dependencies = [
- "hermit-abi 0.4.0",
- "libc",
- "windows-sys 0.52.0",
-]
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -835,33 +917,50 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "1.4.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9ad60d674508f3ca8f380a928cfe7b096bc729c4e2dbfe3852bc45da3ab30b"
+checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
 dependencies = [
+ "jsonptr",
  "serde",
  "serde_json",
  "thiserror",
 ]
 
 [[package]]
-name = "jsonpath_lib"
-version = "0.3.0"
+name = "jsonpath-rust"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
+checksum = "19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200"
 dependencies = [
- "log",
+ "lazy_static",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6e529149475ca0b2820835d3dce8fcc41c6b943ca608d32f35b449255e4627"
+dependencies = [
+ "fluent-uri",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "jsonwebtoken"
-version = "8.3.0"
+version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
 dependencies = [
  "base64 0.21.7",
+ "js-sys",
  "pem",
  "ring",
  "serde",
@@ -871,12 +970,11 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.18.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd990069640f9db34b3b0f7a1afc62a05ffaa3be9b66aa3c313f58346df7f788"
+checksum = "9c8847402328d8301354c94d605481f25a6bdc1ed65471fd96af8eca71141b13"
 dependencies = [
- "base64 0.21.7",
- "bytes",
+ "base64 0.22.1",
  "chrono",
  "serde",
  "serde-value",
@@ -885,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.82.2"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc7d3d52dd5c871991679102e80dfb192faaaa09fecdbccdd8c55af264ce7a8f"
+checksum = "fa21063c854820a77c5d7f8deeb7ffa55246d8304e4bcd8cce2956752c6604f8"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -897,27 +995,30 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.82.2"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "544339f1665488243f79080441cacb09c997746fd763342303e66eebb9d3ba13"
+checksum = "31c2355f5c9d8a11900e71a6fe1e47abd5ec45bf971eb4b162ffe97b46db9bb7"
 dependencies = [
- "base64 0.20.0",
+ "base64 0.22.1",
  "bytes",
  "chrono",
- "dirs-next",
  "either",
  "futures",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "hyper-openssl",
+ "home",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-http-proxy",
+ "hyper-rustls",
  "hyper-timeout",
- "jsonpath_lib",
+ "hyper-util",
+ "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
- "openssl",
  "pem",
- "pin-project",
+ "rustls",
+ "rustls-pemfile",
  "secrecy",
  "serde",
  "serde_json",
@@ -932,54 +1033,57 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.82.2"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25983d07f414dfffba08c5951fe110f649113416b1d8e22f7c89c750eb2555a7"
+checksum = "f3030bd91c9db544a50247e7d48d7db9cf633c172732dce13351854526b1e666"
 dependencies = [
  "chrono",
  "form_urlencoded",
- "http 0.2.12",
+ "http",
  "json-patch",
  "k8s-openapi",
- "once_cell",
  "schemars",
  "serde",
+ "serde-value",
  "serde_json",
  "thiserror",
 ]
 
 [[package]]
 name = "kube-derive"
-version = "0.82.2"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5af652b642aca19ef5194de3506aa39f89d788d5326a570da68b13a02d6c5ba2"
+checksum = "fa98be978eddd70a773aa8e86346075365bfb7eb48783410852dbf7cb57f0c27"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "kube-runtime"
-version = "0.82.2"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125331201e3073707ac79c294c89021faa76c84da3a566a3749a2a93d295c98a"
+checksum = "5895cb8aa641ac922408f128b935652b34c2995f16ad7db0984f6caa50217914"
 dependencies = [
  "ahash",
+ "async-broadcast",
+ "async-stream",
  "async-trait",
  "backoff",
  "derivative",
  "futures",
+ "hashbrown",
  "json-patch",
+ "jsonptr",
  "k8s-openapi",
  "kube-client",
  "parking_lot",
  "pin-project",
  "serde",
  "serde_json",
- "smallvec",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -997,31 +1101,6 @@ name = "libc"
 version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
-
-[[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags",
- "libc",
-]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linked_hash_set"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47186c6da4d81ca383c7c47c1bfc80f4b95f4720514d860a5407aaf4233f9588"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "lock_api"
@@ -1066,7 +1145,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -1122,42 +1201,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "openssl"
-version = "0.10.66"
+name = "openssl-probe"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "ordered-float"
@@ -1167,6 +1214,12 @@ checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1193,11 +1246,12 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "1.1.1"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
+ "serde",
 ]
 
 [[package]]
@@ -1205,6 +1259,51 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project"
@@ -1237,12 +1336,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "powerfmt"
@@ -1334,18 +1427,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355ae415ccd3a04315d3f8246e86d67689ea74d88d915576e1589a351062a13b"
 dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -1379,17 +1461,17 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
+ "getrandom",
  "libc",
- "once_cell",
  "spin",
  "untrusted",
- "web-sys",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1399,10 +1481,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustls"
+version = "0.23.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "schannel"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "schemars"
@@ -1442,6 +1601,29 @@ checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1491,7 +1673,6 @@ version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
- "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -1516,6 +1697,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1576,15 +1768,21 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1606,15 +1804,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -1702,16 +1891,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,13 +1902,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-openssl"
-version = "0.6.5"
+name = "tokio-rustls"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "openssl",
- "openssl-sys",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -1778,18 +1957,16 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "base64 0.21.7",
- "bitflags",
+ "bitflags 2.6.0",
  "bytes",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-range-header",
+ "http",
+ "http-body",
+ "http-body-util",
  "mime",
  "pin-project-lite",
  "tower-layer",
@@ -1856,7 +2033,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.1.0",
+ "http",
  "httparse",
  "log",
  "rand",
@@ -1871,6 +2048,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicode-bidi"
@@ -1901,9 +2084,9 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1923,10 +2106,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
+name = "utf8parse"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"
@@ -2003,56 +2186,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
-
-[[package]]
-name = "web-sys"
-version = "0.3.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,10 +72,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.3.0"
+name = "atomic-waker"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backoff"
@@ -156,9 +162,9 @@ checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "9540e661f81799159abee814118cc139a2004b3a3aa3ea37724a1b66530b90e0"
 dependencies = [
  "shlex",
 ]
@@ -241,6 +247,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "deranged"
@@ -451,10 +463,12 @@ dependencies = [
  "bytes",
  "env_logger",
  "futures",
- "http-body",
+ "http-body 1.0.1",
+ "http-body-util",
  "http-serde",
- "hyper",
+ "hyper 1.4.1",
  "hyper-tungstenite",
+ "hyper-util",
  "jsonwebtoken",
  "k8s-openapi",
  "kube",
@@ -469,6 +483,7 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "tokio-tungstenite",
+ "tungstenite",
  "url",
 ]
 
@@ -501,16 +516,16 @@ checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
- "http",
+ "http 1.1.0",
  "indexmap",
  "slab",
  "tokio",
@@ -548,13 +563,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -566,11 +615,11 @@ checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "http-serde"
-version = "1.1.3"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f560b665ad9f1572cfcaf034f7fb84338a7ce945216d64a90fd81f046a3caee"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
 dependencies = [
- "http",
+ "http 1.1.0",
  "serde",
 ]
 
@@ -602,9 +651,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -617,13 +665,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-openssl"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ee5d7a8f718585d1c3c61dfde28ef5b0bb14734b4db13f5ada856cdc6c612b"
 dependencies = [
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.30",
  "linked_hash_set",
  "once_cell",
  "openssl",
@@ -640,7 +709,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.30",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -648,15 +717,36 @@ dependencies = [
 
 [[package]]
 name = "hyper-tungstenite"
-version = "0.9.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "880b8b1c98a5ec2a505c7c90db6d3f6f1f480af5655d9c5b55facc9382a5a5b5"
+checksum = "426356dc8c52c5a18c5a6c12226c03362f98e4723716074f8010051934cb451c"
 dependencies = [
- "hyper",
- "pin-project",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite",
  "tokio",
  "tokio-tungstenite",
  "tungstenite",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -817,9 +907,9 @@ dependencies = [
  "dirs-next",
  "either",
  "futures",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
  "hyper-openssl",
  "hyper-timeout",
  "jsonpath_lib",
@@ -848,7 +938,7 @@ checksum = "25983d07f414dfffba08c5951fe110f649113416b1d8e22f7c89c750eb2555a7"
 dependencies = [
  "chrono",
  "form_urlencoded",
- "http",
+ "http 0.2.12",
  "json-patch",
  "k8s-openapi",
  "once_cell",
@@ -1645,9 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.18.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
@@ -1697,8 +1787,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "http-range-header",
  "mime",
  "pin-project-lite",
@@ -1759,14 +1849,14 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.18.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
 dependencies = [
- "base64 0.13.1",
  "byteorder",
  "bytes",
- "http",
+ "data-encoding",
+ "http 1.1.0",
  "httparse",
  "log",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "1.0.4"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ remove_authorization_header = []
 [dependencies]
 anyhow = "1.0.53"
 bytes = "1.1.0"
-env_logger = "0.10"
+env_logger = "0.11"
 futures = "0.3.21"
 http-body = "1.0"
 http-body-util = "0.1"
@@ -18,10 +18,10 @@ http-serde = "2.1"
 hyper-tungstenite = "0.15"
 hyper-util = { version = "0.1", features = ["client-legacy", "http1", "server"] }
 hyper = { version = "1.4", features = ["full"] }
-jsonwebtoken = "8.0.1"
-k8s-openapi = { version = "0.18", default-features = false, features = ["v1_21"] }
-kube-runtime = "0.82"
-kube = { version = "0.82", features = ["derive"] }
+jsonwebtoken = "9.3"
+k8s-openapi = { version = "0.23", default-features = false, features = ["v1_31"] }
+kube-runtime = "0.95"
+kube = { version = "0.95", features = ["derive"] }
 log = "0.4.14"
 once_cell = "1.9.0"
 prometheus = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,27 +4,33 @@ version = "1.0.4"
 authors = ["pguenezan <paul@guenezan.me>"]
 edition = "2021"
 
+[features]
+remove_authorization_header = []
+
 [dependencies]
-hyper = { version = "0.14.16", features = ["full"] }
-tokio = { version = "1.16.1", features = ["full"] }
-http-body = "0.4.4"
-jsonwebtoken = "8.0.1"
-serde = { version = "1.0.136", features = ["derive"] }
-serde_json = "1.0.78"
-serde_yaml = "0.9"
+anyhow = "1.0.53"
 bytes = "1.1.0"
+env_logger = "0.10"
+futures = "0.3.21"
+http-body = "1.0"
+http-body-util = "0.1"
+http-serde = "2.1"
+hyper-tungstenite = "0.15"
+hyper-util = { version = "0.1", features = ["client-legacy", "http1", "server"] }
+hyper = { version = "1.4", features = ["full"] }
+jsonwebtoken = "8.0.1"
+k8s-openapi = { version = "0.18", default-features = false, features = ["v1_21"] }
+kube-runtime = "0.82"
+kube = { version = "0.82", features = ["derive"] }
+log = "0.4.14"
+once_cell = "1.9.0"
 prometheus = "0.13.0"
 regex = "1.5.4"
-once_cell = "1.9.0"
-http-serde = "1.1.0"
-log = "0.4.14"
-env_logger = "0.10"
-kube = { version = "0.82", features = ["derive"] }
-kube-runtime = "0.82"
-k8s-openapi = { version = "0.18", default-features = false, features = ["v1_21"] }
-url = "2.2.2"
 schemars = "0.8.8"
-futures = "0.3.21"
-hyper-tungstenite = "0.9"
-tokio-tungstenite = "0.18"
-anyhow = "1.0.53"
+serde_json = "1.0.78"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_yaml = "0.9"
+tokio-tungstenite = "0.24"
+tokio = { version = "1.16", features = ["full"] }
+tungstenite = { version = "0.24", features = ["url"] }
+url = "2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ k8s-openapi = { version = "0.23", default-features = false, features = ["v1_31"]
 kube-runtime = "0.95"
 kube = { version = "0.95", features = ["derive"] }
 log = "0.4.14"
-once_cell = "1.9.0"
 prometheus = "0.13.0"
 regex = "1.5.4"
 schemars = "0.8.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway"
-version = "1.0.4"
+version = "2.0.0"
 authors = ["pguenezan <paul@guenezan.me>"]
 edition = "2021"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY src ./src
 RUN cargo install --path .
 
 
-FROM debian:bookworm-20240926-slim
+FROM debian:12-slim@sha256:ad86386827b083b3d71139050b47ffb32bbd9559ea9b1345a739b14fec2d9ecf
 RUN apt-get -y update && \
     apt-get -y install libssl3 && \
     apt-get clean autoclean && \
@@ -21,5 +21,3 @@ COPY --from=builder /usr/local/cargo/bin/gateway /home/app/gateway
 WORKDIR /home/app
 USER 1000
 CMD ["/home/app/gateway", "/config/runtime_config.yaml"]
-
-

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ max_fetch_error_count: u64 # max number of consecutive errors when fetching perm
 
 # TODO: arbitrary values
 websocket_config:
-  write_buffer_size: 1_000
-  max_write_buffer_size: 1_000
+  write_buffer_size: 10_000
+  max_write_buffer_size: 10_000
   max_message_size: 1_000_000
   max_frame_size: 1_000_000
   accept_unmasked_frames: true

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ max_fetch_error_count: u64 # max number of consecutive errors when fetching perm
 
 # TODO: arbitrary values
 websocket_config:
-  max_send_queue: 1000
+  write_buffer_size: 1_000
+  max_write_buffer_size: 1_000
   max_message_size: 1_000_000
   max_frame_size: 1_000_000
   accept_unmasked_frames: true

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,12 +1,11 @@
+use anyhow::Result;
+use kube::core::DynamicObject;
+use kube::CustomResource;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use kube::CustomResource;
-use schemars::JsonSchema;
-
 use crate::endpoint::Endpoint;
-use anyhow::Result;
-use kube::core::DynamicObject;
 
 #[derive(Deserialize, Serialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all(deserialize = "snake_case"))]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
+use std::sync::LazyLock;
 
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
-use once_cell::sync::Lazy;
 use serde::Deserialize;
 
 use crate::runtime_config::{AuthSource, RUNTIME_CONFIG};
@@ -52,7 +52,7 @@ impl TokenSource {
     }
 }
 
-static TOKEN_SOURCES: Lazy<Vec<TokenSource>> = Lazy::new(|| {
+static TOKEN_SOURCES: LazyLock<Vec<TokenSource>> = LazyLock::new(|| {
     RUNTIME_CONFIG
         .auth_sources
         .iter()

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -1,12 +1,12 @@
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 use hyper::Method;
-use once_cell::sync::Lazy;
 use regex::Regex;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-static PATH_TO_PERM: Lazy<Regex> = Lazy::new(|| Regex::new("\\{[^/]*\\}").unwrap());
+static PATH_TO_PERM: LazyLock<Regex> = LazyLock::new(|| Regex::new("\\{[^/]*\\}").unwrap());
 
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 pub struct Endpoint {

--- a/src/fetch_crd.rs
+++ b/src/fetch_crd.rs
@@ -1,20 +1,18 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::RwLock;
 
-use kube::api::{Api, DynamicObject};
-use kube::{discovery, Client};
-
+use anyhow::{bail, Result};
 use futures::{StreamExt, TryStreamExt};
+use kube::api::{Api, DynamicObject};
+use kube::core::GroupVersionKind;
+use kube::{discovery, Client};
 use kube_runtime::utils::WatchStreamExt;
 use kube_runtime::watcher;
 use kube_runtime::watcher::Config;
-
-use anyhow::{bail, Result};
+use tokio::sync::RwLock;
 
 use crate::api::ApiDefinition;
 use crate::route::Node;
-use kube::core::GroupVersionKind;
 
 pub async fn update_api(
     api_lock: Arc<RwLock<HashMap<String, (ApiDefinition, Node)>>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,29 @@
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::process::exit;
+use std::sync::Arc;
 use std::time::Instant;
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Result};
+use bytes::Bytes;
 use http_body::SizeHint;
-use hyper::body::HttpBody;
-use hyper::client::HttpConnector;
+use http_body_util::combinators::BoxBody;
+use http_body_util::{BodyExt, Full};
+use hyper::body::{Body, Incoming};
 use hyper::header::{
     HeaderValue, ACCESS_CONTROL_ALLOW_CREDENTIALS, ACCESS_CONTROL_ALLOW_HEADERS,
     ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_MAX_AGE,
     AUTHORIZATION, CONTENT_TYPE,
 };
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Client, HeaderMap, Method, Request, Response, Server, StatusCode, Uri};
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{HeaderMap, Method, Request, Response, StatusCode, Uri};
 use hyper_tungstenite::is_upgrade_request;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::client::legacy::Client;
+use hyper_util::rt::{TokioExecutor, TokioIo};
 use prometheus::{Encoder, TextEncoder};
-use std::sync::Arc;
+use tokio::net::TcpListener;
 use tokio::sync::RwLock;
 use url::Url;
 
@@ -43,14 +50,21 @@ use crate::websocket::handle_upgrade;
 #[macro_use]
 extern crate log;
 
-type GenericError = Box<dyn std::error::Error + Send + Sync>;
-type Result<T> = std::result::Result<T, GenericError>;
+type BoxResponse<D> = Response<BoxBody<D, anyhow::Error>>;
 
 static OK: &[u8] = b"Ok";
 static NOT_FOUND: &[u8] = b"Not Found";
 static FORBIDDEN: &[u8] = b"Forbidden";
 static BAD_GATEWAY: &[u8] = b"Bad Gateway";
 static NO_CONTENT: &[u8] = b"";
+
+fn into_boxed_response<B>(response: Response<B>) -> BoxResponse<B::Data>
+where
+    B: Body + Send + Sync + 'static,
+    B::Error: std::error::Error + Send + Sync,
+{
+    response.map(|body| body.map_err(|err| anyhow!("Invalid Body: {err}")).boxed())
+}
 
 #[inline(always)]
 fn get_response(
@@ -60,8 +74,8 @@ fn get_response(
     content: &'static [u8],
     start_time: &Instant,
     req_size: &SizeHint,
-) -> Result<Response<Body>> {
-    let response = Response::builder()
+) -> Result<Response<Full<Bytes>>> {
+    let response: Response<Full<Bytes>> = Response::builder()
         .status(status_code)
         .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
         .header(ACCESS_CONTROL_ALLOW_HEADERS, "*")
@@ -76,11 +90,10 @@ fn get_response(
         start_time,
         status_code,
         req_size,
-        &response.size_hint(),
+        &response.body().size_hint(),
     );
 
     debug!("event='Response built'");
-
     Ok(response)
 }
 
@@ -132,7 +145,7 @@ fn inject_headers(
     }
 }
 
-async fn metrics() -> Result<Response<Body>> {
+async fn metrics() -> Result<Response<Full<Bytes>>> {
     let encoder = TextEncoder::new();
     let metric_families = prometheus::gather();
     let mut buffer = vec![];
@@ -141,13 +154,13 @@ async fn metrics() -> Result<Response<Body>> {
     let response = Response::builder()
         .status(200)
         .header(CONTENT_TYPE, encoder.format_type())
-        .body(Body::from(buffer))
+        .body(buffer.into())
         .unwrap();
 
     Ok(response)
 }
 
-async fn health() -> Result<Response<Body>> {
+async fn health() -> Result<Response<Full<Bytes>>> {
     Ok(Response::builder()
         .status(StatusCode::OK)
         .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
@@ -159,8 +172,8 @@ async fn health() -> Result<Response<Body>> {
 
 #[allow(clippy::too_many_arguments)]
 async fn call(
-    mut req: Request<Body>,
-    client: &Client<HttpConnector>,
+    mut req: Request<Incoming>,
+    client: &Client<HttpConnector, Incoming>,
     perm_lock: Arc<RwLock<HashMap<String, HashSet<String>>>>,
     role_lock: Arc<RwLock<HashMap<String, HashMap<String, String>>>>,
     endpoint: &Endpoint,
@@ -172,8 +185,9 @@ async fn call(
     http_uri_string: &str,
     ws_uri_string: &str,
     token_type: &str,
-) -> Result<Response<Body>> {
+) -> Result<BoxResponse<Bytes>> {
     let path = &req.uri().path().to_owned();
+
     if endpoint.check_permission
         && !has_perm(perm_lock, &endpoint.permission, &claims.token_id).await
     {
@@ -186,6 +200,7 @@ async fn call(
             claims.token_id,
             &endpoint.permission,
         );
+
         return get_response(
             app,
             req.method(),
@@ -193,11 +208,14 @@ async fn call(
             FORBIDDEN,
             start_time,
             req_size,
-        );
+        )
+        .map(into_boxed_response);
     }
 
     if endpoint.is_websocket && is_upgrade_request(&req) {
-        return handle_upgrade(app, req, start_time, req_size, ws_uri_string).await;
+        return handle_upgrade(app, req, start_time, req_size, ws_uri_string)
+            .await
+            .map(into_boxed_response);
     }
 
     if endpoint.is_websocket {
@@ -210,13 +228,15 @@ async fn call(
             NO_CONTENT,
             start_time,
             req_size,
-        );
+        )
+        .map(into_boxed_response);
     }
 
     match http_uri_string.parse() {
         Ok(uri) => *req.uri_mut() = uri,
         Err(e) => {
             error!("error='Uri parsing error: {:?}'", e);
+
             return get_response(
                 app,
                 req.method(),
@@ -224,9 +244,11 @@ async fn call(
                 NOT_FOUND,
                 start_time,
                 req_size,
-            );
+            )
+            .map(into_boxed_response);
         }
     };
+
     let role_read = role_lock.read().await;
     let roles = match role_read.get(&claims.token_id) {
         None => "",
@@ -248,6 +270,7 @@ async fn call(
     match response {
         Ok(mut response) => {
             inject_cors(response.headers_mut());
+
             commit_http_metrics(
                 app,
                 &method,
@@ -256,6 +279,7 @@ async fn call(
                 req_size,
                 &response.size_hint(),
             );
+
             info!(
                 "method='{}' path='{}' uri='{}' status_code='{}' user_sub='{}' token_id='{}' perm='{}' duration='{}ms'",
                 method,
@@ -267,7 +291,8 @@ async fn call(
                 &endpoint.permission,
                 request_duration_ms,
             );
-            Ok(response)
+
+            Ok(into_boxed_response(response))
         }
         Err(error) => {
             warn!(
@@ -281,6 +306,7 @@ async fn call(
                 &endpoint.permission,
                 request_duration_ms,
             );
+
             get_response(
                 app,
                 &method,
@@ -289,6 +315,7 @@ async fn call(
                 start_time,
                 req_size,
             )
+            .map(into_boxed_response)
         }
     }
 }
@@ -306,20 +333,20 @@ fn get_auth_from_url(uri: &Uri) -> Option<String> {
 }
 
 async fn response(
-    req: Request<Body>,
-    client: Client<HttpConnector>,
+    req: Request<Incoming>,
+    client: Client<HttpConnector, Incoming>,
     perm_lock: Arc<RwLock<HashMap<String, HashSet<String>>>>,
     role_lock: Arc<RwLock<HashMap<String, HashMap<String, String>>>>,
     api_lock: Arc<RwLock<HashMap<String, (ApiDefinition, Node)>>>,
-) -> Result<Response<Body>> {
+) -> Result<BoxResponse<Bytes>> {
     match req.uri().path() {
         "/metrics" => {
             debug!("event='Metrics endpoint'");
-            return metrics().await;
+            return metrics().await.map(into_boxed_response);
         }
         "/health" => {
             debug!("event='Health endpoint'");
-            return health().await;
+            return health().await.map(into_boxed_response);
         }
         _ => (),
     };
@@ -340,7 +367,8 @@ async fn response(
             NO_CONTENT,
             &start_time,
             &req_size,
-        );
+        )
+        .map(into_boxed_response);
     }
 
     let slash_index = match path[1..].find('/') {
@@ -354,7 +382,8 @@ async fn response(
                 NOT_FOUND,
                 &start_time,
                 &req_size,
-            );
+            )
+            .map(into_boxed_response);
         }
     };
     let app = &path[..slash_index];
@@ -370,7 +399,8 @@ async fn response(
                     FORBIDDEN,
                     &start_time,
                     &req_size,
-                );
+                )
+                .map(into_boxed_response);
             }
             Some(authorization) => authorization,
         },
@@ -384,7 +414,8 @@ async fn response(
                     FORBIDDEN,
                     &start_time,
                     &req_size,
-                );
+                )
+                .map(into_boxed_response);
             }
             Ok(authorization) => authorization.to_string(),
         },
@@ -400,7 +431,8 @@ async fn response(
                 FORBIDDEN,
                 &start_time,
                 &req_size,
-            );
+            )
+            .map(into_boxed_response);
         }
     };
 
@@ -415,7 +447,8 @@ async fn response(
                 NOT_FOUND,
                 &start_time,
                 &req_size,
-            );
+            )
+            .map(into_boxed_response);
         }
     };
 
@@ -432,6 +465,7 @@ async fn response(
                 &start_time,
                 &req_size,
             )
+            .map(into_boxed_response)
         }
         Some((api, node)) => match api.spec.mode {
             ApiMode::ForwardAll => {
@@ -471,6 +505,7 @@ async fn response(
                             &start_time,
                             &req_size,
                         )
+                        .map(into_boxed_response)
                     }
                     Some(endpoint) => {
                         let http_uri_string = format!("{}{}", &api.spec.uri_http, forwarded_uri);
@@ -521,34 +556,56 @@ async fn main() -> Result<()> {
     let update_api = update_api(api_lock.clone(), RUNTIME_CONFIG.crd_label.to_owned());
 
     // Share a `Client` with all `Service`s
-    let client = Client::new();
+    let client = Client::builder(TokioExecutor::new()).build_http();
 
-    let make_service = make_service_fn(move |_| {
-        // Move a clone of `client`, `perm_lock` and `role_lock` into the `make_service`.
-        let client = client.clone();
-        let perm_lock = perm_lock.clone();
-        let role_lock = role_lock.clone();
-        let api_lock = api_lock.clone();
-        async {
-            Ok::<_, GenericError>(service_fn(move |req| {
-                // Clone again to ensure that `client`, `perm_lock` and `role_lock` outlives this closure.
-                response(
-                    req,
-                    client.to_owned(),
-                    perm_lock.clone(),
-                    role_lock.clone(),
-                    api_lock.clone(),
-                )
-            }))
-        }
+    let service = service_fn(move |req| {
+        response(
+            req,
+            client.to_owned(),
+            perm_lock.clone(),
+            role_lock.clone(),
+            api_lock.clone(),
+        )
     });
 
-    let server = Server::bind(&addr).serve(make_service);
+    let listener = TcpListener::bind(&addr)
+        .await
+        .map_err(|err| anyhow!("Could not listen on {addr}: {err}"))?;
+
     info!("event='Listening on http://{}'", addr);
 
     let res = tokio::try_join!(update_perm, update_api, async {
-        server.await.map_err(|e| anyhow!(e))
+        loop {
+            let stream = match listener.accept().await {
+                Ok((stream, _socket)) => stream,
+                Err(err) => {
+                    error!("Failed to accept connection: {err:?}");
+                    continue;
+                }
+            };
+
+            let io = TokioIo::new(stream);
+            let service = service.clone();
+
+            tokio::task::spawn(async move {
+                if let Err(err) = http1::Builder::new()
+                    .preserve_header_case(true)
+                    .title_case_headers(true)
+                    .serve_connection(io, service)
+                    .with_upgrades()
+                    .await
+                {
+                    error!("Failed to serve connection: {err:?}");
+                }
+            });
+        }
+
+        // This part is unreachable but we still define a return value to help
+        // type inference of the async block.
+        #[allow(unreachable_code)]
+        Result::Ok(())
     });
+
     match res {
         Ok((_, _, _)) => info!("That went well"),
         Err(e) => {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,9 +1,9 @@
+use std::sync::LazyLock;
 use std::time::Instant;
 
 use http_body::SizeHint;
 use hyper::Method;
 use hyper::StatusCode;
-use once_cell::sync::Lazy;
 use prometheus::{
     exponential_buckets, opts, register_counter_vec, register_gauge_vec, register_histogram_vec,
     CounterVec, GaugeVec, HistogramVec,
@@ -116,7 +116,7 @@ fn get_metric_name(name: &str, protocol: Protocol) -> String {
     )
 }
 
-static HTTP_COUNTER: Lazy<CounterVec> = Lazy::new(|| {
+static HTTP_COUNTER: LazyLock<CounterVec> = LazyLock::new(|| {
     register_counter_vec!(
         opts!(
             get_metric_name("requests_total", Protocol::Http),
@@ -127,7 +127,7 @@ static HTTP_COUNTER: Lazy<CounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-static HTTP_REQ_LAT_HISTOGRAM: Lazy<HistogramVec> = Lazy::new(|| {
+static HTTP_REQ_LAT_HISTOGRAM: LazyLock<HistogramVec> = LazyLock::new(|| {
     register_histogram_vec!(
         get_metric_name("request_duration_seconds", Protocol::Http),
         "The HTTP request latencies in seconds.",
@@ -136,7 +136,7 @@ static HTTP_REQ_LAT_HISTOGRAM: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-static HTTP_REQ_SIZE_HISTOGRAM_LOW: Lazy<HistogramVec> = Lazy::new(|| {
+static HTTP_REQ_SIZE_HISTOGRAM_LOW: LazyLock<HistogramVec> = LazyLock::new(|| {
     register_histogram_vec!(
         get_metric_name("request_size_low_bytes", Protocol::Http),
         "The HTTP request size in bytes (lower bound).",
@@ -146,7 +146,7 @@ static HTTP_REQ_SIZE_HISTOGRAM_LOW: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-static HTTP_REQ_SIZE_HISTOGRAM_HIGH: Lazy<HistogramVec> = Lazy::new(|| {
+static HTTP_REQ_SIZE_HISTOGRAM_HIGH: LazyLock<HistogramVec> = LazyLock::new(|| {
     register_histogram_vec!(
         get_metric_name("request_size_high_bytes", Protocol::Http),
         "The HTTP request size in bytes (upper bound).",
@@ -156,7 +156,7 @@ static HTTP_REQ_SIZE_HISTOGRAM_HIGH: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-static HTTP_RES_SIZE_HISTOGRAM_LOW: Lazy<HistogramVec> = Lazy::new(|| {
+static HTTP_RES_SIZE_HISTOGRAM_LOW: LazyLock<HistogramVec> = LazyLock::new(|| {
     register_histogram_vec!(
         get_metric_name("response_size_low_bytes", Protocol::Http),
         "The HTTP response size in bytes (lower bound).",
@@ -166,7 +166,7 @@ static HTTP_RES_SIZE_HISTOGRAM_LOW: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-static HTTP_RES_SIZE_HISTOGRAM_HIGH: Lazy<HistogramVec> = Lazy::new(|| {
+static HTTP_RES_SIZE_HISTOGRAM_HIGH: LazyLock<HistogramVec> = LazyLock::new(|| {
     register_histogram_vec!(
         get_metric_name("response_size_high_bytes", Protocol::Http),
         "The HTTP response size in bytes (upper bound).",
@@ -176,7 +176,7 @@ static HTTP_RES_SIZE_HISTOGRAM_HIGH: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-static SOCKET_CONNECTED_GAUGE: Lazy<GaugeVec> = Lazy::new(|| {
+static SOCKET_CONNECTED_GAUGE: LazyLock<GaugeVec> = LazyLock::new(|| {
     register_gauge_vec!(
         get_metric_name("clients", Protocol::Socket),
         "Number simultaneously open sockets",
@@ -185,7 +185,7 @@ static SOCKET_CONNECTED_GAUGE: Lazy<GaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
-static SOCKET_MESSAGE_SENT_COUNTER: Lazy<CounterVec> = Lazy::new(|| {
+static SOCKET_MESSAGE_SENT_COUNTER: LazyLock<CounterVec> = LazyLock::new(|| {
     register_counter_vec!(
         get_metric_name("message_sent", Protocol::Socket),
         "Total number of messages sent from server through sockets",
@@ -194,7 +194,7 @@ static SOCKET_MESSAGE_SENT_COUNTER: Lazy<CounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-static SOCKET_MESSAGE_RECV_COUNTER: Lazy<CounterVec> = Lazy::new(|| {
+static SOCKET_MESSAGE_RECV_COUNTER: LazyLock<CounterVec> = LazyLock::new(|| {
     register_counter_vec!(
         get_metric_name("message_received", Protocol::Socket),
         "Total number of messages received by server through sockets",
@@ -203,7 +203,7 @@ static SOCKET_MESSAGE_RECV_COUNTER: Lazy<CounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-static SOCKET_MESSAGE_SENT_SIZE_HISTOGRAM: Lazy<HistogramVec> = Lazy::new(|| {
+static SOCKET_MESSAGE_SENT_SIZE_HISTOGRAM: LazyLock<HistogramVec> = LazyLock::new(|| {
     register_histogram_vec!(
         get_metric_name("message_sent_size", Protocol::Socket),
         "Size of messages sent from server through sockets in bytes",
@@ -213,7 +213,7 @@ static SOCKET_MESSAGE_SENT_SIZE_HISTOGRAM: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-static SOCKET_MESSAGE_RECV_SIZE_HISTOGRAM: Lazy<HistogramVec> = Lazy::new(|| {
+static SOCKET_MESSAGE_RECV_SIZE_HISTOGRAM: LazyLock<HistogramVec> = LazyLock::new(|| {
     register_histogram_vec!(
         get_metric_name("message_received_size", Protocol::Socket),
         "Size of messages received by server through sockets in bytes",

--- a/src/permission.rs
+++ b/src/permission.rs
@@ -1,22 +1,19 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use serde::Deserialize;
-
-use bytes::Buf as _;
-
+use anyhow::{bail, Result};
+use bytes::{Bytes, BytesMut};
+use futures::TryStreamExt;
+use http_body_util::{BodyExt, Full};
+use hyper_util::client::legacy::Client;
+use hyper_util::rt::TokioExecutor;
+use once_cell::sync::Lazy;
 use regex::Regex;
-
-use hyper::Client;
-
+use serde::Deserialize;
 use tokio::sync::RwLock;
 use tokio::time::{sleep, Duration};
 
-use anyhow::bail;
-
 use crate::runtime_config::{PermUri, RUNTIME_CONFIG};
-
-use anyhow::Result;
 
 #[derive(Deserialize, Debug)]
 struct Perm {
@@ -26,29 +23,27 @@ struct Perm {
 
 type PermList = Vec<Perm>;
 
+static IS_ROLE_PERM: Lazy<Regex> = Lazy::new(|| Regex::new("([^:]+)::roles::(.*)").unwrap());
+
 async fn fetch_perm(perm_uri: &PermUri) -> Option<PermList> {
-    let client = Client::new();
-    let res = match client.get(perm_uri.uri.clone()).await {
-        Ok(res) => res,
-        Err(e) => {
-            error!("fail to fetch {:?}: {}", perm_uri, e);
-            return None;
-        }
-    };
-    let body = match hyper::body::aggregate(res).await {
-        Ok(body) => body,
-        Err(e) => {
-            error!("fail to fetch {:?}: {}", perm_uri, e);
-            return None;
-        }
-    };
-    match serde_json::from_reader(body.reader()) {
-        Ok(json) => json,
-        Err(e) => {
-            error!("fail to fetch {:?}: {}", perm_uri, e);
-            None
-        }
-    }
+    let client = Client::builder(TokioExecutor::new()).build_http::<Full<Bytes>>();
+
+    let res = client
+        .get(perm_uri.uri.clone())
+        .await
+        .inspect_err(|e| error!("fail to fetch {perm_uri:?}: {e}"))
+        .ok()?;
+
+    let body: BytesMut = res
+        .into_data_stream()
+        .try_collect()
+        .await
+        .inspect_err(|e| error!("fail to fetch {perm_uri:?}: {e}"))
+        .ok()?;
+
+    serde_json::from_slice(&body)
+        .inspect_err(|e| error!("fail to fetch {perm_uri:?}: {e}"))
+        .ok()
 }
 
 pub async fn get_perm() -> Result<(
@@ -56,15 +51,13 @@ pub async fn get_perm() -> Result<(
     HashMap<String, HashMap<String, String>>,
 )> {
     let mut perm_hm: HashMap<String, HashSet<String>> = HashMap::new();
-    let is_role_perm = Regex::new("([^:]+)::roles::(.*)").unwrap();
     let mut user_role = HashMap::new();
 
     for perm_uri in RUNTIME_CONFIG.perm_uris.iter().as_ref() {
         match fetch_perm(perm_uri).await {
             Some(perm_vec) => {
                 for perm in perm_vec.iter() {
-                    if is_role_perm.is_match(&perm.role_name) {
-                        let captures = is_role_perm.captures(&perm.role_name).unwrap();
+                    if let Some(captures) = IS_ROLE_PERM.captures(&perm.role_name) {
                         let app_name = captures.get(1).unwrap().as_str();
                         let role_name = captures.get(2).unwrap().as_str();
                         for user_id in perm.user_id.iter() {

--- a/src/permission.rs
+++ b/src/permission.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use anyhow::{bail, Result};
 use bytes::{Bytes, BytesMut};
@@ -7,7 +7,6 @@ use futures::TryStreamExt;
 use http_body_util::{BodyExt, Full};
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioExecutor;
-use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::Deserialize;
 use tokio::sync::RwLock;
@@ -23,7 +22,8 @@ struct Perm {
 
 type PermList = Vec<Perm>;
 
-static IS_ROLE_PERM: Lazy<Regex> = Lazy::new(|| Regex::new("([^:]+)::roles::(.*)").unwrap());
+static IS_ROLE_PERM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new("([^:]+)::roles::(.*)").unwrap());
 
 async fn fetch_perm(perm_uri: &PermUri) -> Option<PermList> {
     let client = Client::builder(TokioExecutor::new()).build_http::<Full<Bytes>>();

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::api::{ApiDefinition, ApiMode};
 use crate::endpoint::Endpoint;
 
-static IS_PARAM: Lazy<Regex> = Lazy::new(|| Regex::new("\\{[^/]*\\}").unwrap());
+static IS_PARAM: LazyLock<Regex> = LazyLock::new(|| Regex::new("\\{[^/]*\\}").unwrap());
 
 #[derive(Debug)]
 pub struct Node {

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -27,7 +27,8 @@ pub struct AuthSource {
 
 #[derive(Debug, Deserialize)]
 struct WebSocketConfigInternal {
-    max_send_queue: usize,
+    write_buffer_size: usize,
+    max_write_buffer_size: usize,
     max_message_size: usize,
     max_frame_size: usize,
     accept_unmasked_frames: bool,
@@ -79,10 +80,12 @@ fn get_runtime_config<P: AsRef<Path>>(path: P) -> Result<RuntimeConfig> {
 impl RuntimeConfig {
     pub fn get_websocket_config(&self) -> WebSocketConfig {
         WebSocketConfig {
-            max_send_queue: Some(self.websocket_config.max_send_queue),
+            write_buffer_size: self.websocket_config.write_buffer_size,
+            max_write_buffer_size: self.websocket_config.max_write_buffer_size,
             max_message_size: Some(self.websocket_config.max_message_size),
             max_frame_size: Some(self.websocket_config.max_frame_size),
             accept_unmasked_frames: self.websocket_config.accept_unmasked_frames,
+            ..Default::default()
         }
     }
 }

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -4,9 +4,9 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 use std::process::exit;
+use std::sync::LazyLock;
 
 use hyper::http::Uri;
-use once_cell::sync::Lazy;
 use serde::Deserialize;
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 
@@ -48,7 +48,7 @@ pub struct RuntimeConfig {
 
 type Result<T> = std::result::Result<T, Box<dyn error::Error>>;
 
-pub static RUNTIME_CONFIG: Lazy<RuntimeConfig> = Lazy::new(|| {
+pub static RUNTIME_CONFIG: LazyLock<RuntimeConfig> = LazyLock::new(|| {
     let args: Vec<String> = env::args().collect();
 
     if args.len() != 2 {


### PR DESCRIPTION
⚠️ Based on #30 

See https://hyper.rs/guides/1/upgrading/ for an overall of what has changed in hyper 1.0

I also took my chance to get rid of once_cell which is now part of the standard library.