### PR TITLE
PCX-318: feat(CORS): add standard expose-headers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,8 @@ use hyper::body::HttpBody;
 use hyper::client::HttpConnector;
 use hyper::header::{
     HeaderValue, ACCESS_CONTROL_ALLOW_CREDENTIALS, ACCESS_CONTROL_ALLOW_HEADERS,
-    ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_MAX_AGE,
-    AUTHORIZATION, CONTENT_TYPE,
+    ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_EXPOSE_HEADERS,
+    ACCESS_CONTROL_MAX_AGE, AUTHORIZATION, CONTENT_TYPE,
 };
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Client, HeaderMap, Method, Request, Response, Server, StatusCode, Uri};
@@ -66,6 +66,7 @@ fn get_response(
         .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
         .header(ACCESS_CONTROL_ALLOW_HEADERS, "*")
         .header(ACCESS_CONTROL_ALLOW_METHODS, "*")
+        .header(ACCESS_CONTROL_EXPOSE_HEADERS, "Location, Retry-After")
         .header(ACCESS_CONTROL_ALLOW_CREDENTIALS, "true")
         .header(ACCESS_CONTROL_MAX_AGE, 86400)
         .body(content.into())?;


### PR DESCRIPTION
The goal of this Merge Request is to add the CORS header Access-Control-Expose-Headers.

The goal of this header is to allow frontend scripts to access some headers, otherwise they are not available.

The wildcard "*" doesn't work on this header, so some standard headers were added :
- Location : generally containing an endpoint to be called,
- Retry-After : generally containing a number that represent the number of second to wait before retrying the call of a route.