### PR TITLE
fix websocket extension header forwarded to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.2.1
+
+- Fix `Sec-WebSocket-Extensions` header being forwarded while the gateway does
+  not support any extension protocol.
+
 # 2.2.0
 
 - Forward method and headers for websocket requests.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "gateway"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gateway"
-version = "2.2.0"
+version = "2.2.1"
 authors = ["pguenezan <paul@guenezan.me>"]
 edition = "2021"
 

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -153,6 +153,7 @@ async fn serve_websocket(
                     warn!("event='Fail to close server socket: {:?}'", e);
                 }
             }
+
             while let Some(message) = rx_server.next().await {
                 match message {
                     Err(e) => {


### PR DESCRIPTION
In case the client claims it supports a websocket extension (eg. per-message deflate), the gateway was forwarding that claim to the server which was then free to use a protocol that the gateway does NOT support.