### PR TITLE
fix: add expose-headers to all calls

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,7 @@ fn get_response(
 
 fn inject_cors(headers: &mut HeaderMap<HeaderValue>) {
     headers.insert(ACCESS_CONTROL_ALLOW_ORIGIN, "*".parse().unwrap());
+    headers.insert(ACCESS_CONTROL_EXPOSE_HEADERS, "location, retry-after".parse().unwrap());
 }
 
 fn inject_headers(


### PR DESCRIPTION
Le header de cors access-control-expose-headers est renvoyé par toutes les routes. En effet, ce dernier est censé être présent dans les routes l'utilisant et pas seulement dans leurs pre-flight request, afin d'être utilisable par un frontend.